### PR TITLE
Applying some ansible-lint and flake8 suggestions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,9 @@ Release Summary
 ---------------
 
 - Added options to override default role behaviors for environments not using the VSCode dev container.
-- Introduced conditional dependency on the geerlingguy.docker role for RHEL8 setups, following AWS ECS agent setup guidelines.
+- Optional variable to provide AWS SSO profile for running activation
+- Introduced conditional dependency on the geerlingguy.docker role for EL8 based setups, following AWS ECS agent setup guidelines.
 - Resolved issue reported for fixing syntax error in `tasks/deregister-ssm-instance.yml`.
-- Syntax improvements as identified by ansible-lint for code quality.
+- Syntax improvements as identified by ansible-lint and flake8 for code quality.
+- Added a changelog.
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ This role requires Ansible 2.4 or higher and AWS CLI v2.
 
 | variable | description | required? | default |
 | -------- | ----------- | ---------- | ------- | 
-| iam_role | Which IAM role to associate with instance | yes | - |
-| aws_ecs_cluster | Name of ECS cluster to use | yes | - |
-| aws_region | Which region to use for this ECS instance | yes | `us-west-2` |
-| aws_install_dir | Where to install ECS anywhere | no | `/opt/amazon/ecs-anywhere` |
-| aws_script_url | Location of install script | no | `https://amazon-ecs-agent.s3.amazonaws.com/ecs-anywhere-install-latest.sh` |
-| use_sudo_for_local_tasks | Override default sudo behaviour for local tasks | no | true |
-| aws_sso_profile | SSO profile used to run local task | no | omit |
-| include_docker_role | Install docker as a dependnecy | no | when os = rhel8 |
+| ecs_anywhere_iam_role | Which IAM role to associate with instance | yes | - |
+| ecs_anywhere_aws_ecs_cluster | Name of ECS cluster to use | yes | - |
+| ecs_anywhere_aws_region | Which region to use for this ECS instance | yes | `us-west-2` |
+| ecs_anywhere_aws_install_dir | Where to install ECS anywhere | no | `/opt/amazon/ecs-anywhere` |
+| ecs_anywhere_aws_script_url | Location of install script | no | `https://amazon-ecs-agent.s3.amazonaws.com/ecs-anywhere-install-latest.sh` |
+| ecs_anywhere_use_sudo_for_local_tasks | Override default sudo behaviour for local tasks | no | true |
+| ecs_anywhere_aws_sso_profile | SSO profile used to run local task | no | omit |
+| ecs_anywhere_include_docker_role | Install docker as a dependnecy | no | when os = rhel8 |
 
 ## Example Playbooks
 
@@ -43,9 +43,9 @@ Install ECS and SSM agents and register SSM node
       name: gaggle_net.ecs_anywhere.ecs_anywhere
       tasks_from: aws-script-install
     vars:
-      iam_role: ecsAnywhereRole
-      aws_ecs_cluster: ecs-anywhere
-      aws_region: us-west-2
+      ecs_anywhere_iam_role: ecsAnywhereRole
+      ecs_anywhere_aws_ecs_cluster: ecs-anywhere
+      ecs_anywhere_aws_region: us-west-2
 
 ```
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -7,14 +7,14 @@ releases:
 
         - Optional variable to provide AWS SSO profile for running activation
 
-        - Introduced conditional dependency on the geerlingguy.docker role for RHEL8
-        setups, following AWS ECS agent setup guidelines.
+        - Introduced conditional dependency on the geerlingguy.docker role for EL8
+        based setups, following AWS ECS agent setup guidelines.
 
         - Resolved issue reported for fixing syntax error in `tasks/deregister-ssm-instance.yml`.
 
-        - Syntax improvements as identified by ansible-lint for code quality.
+        - Syntax improvements as identified by ansible-lint and flake8 for code quality.
 
-        - Added a changelog :)
+        - Added a changelog.
 
         '
     release_date: '2023-12-09'

--- a/playbooks/deregister-ssm-instance.yml
+++ b/playbooks/deregister-ssm-instance.yml
@@ -2,9 +2,9 @@
 - name: Deregister SSM Instance in AWS ECS
   hosts: aws_ecs
   vars:
-    aws_region: us-west-2
-    aws_ecs_cluster: ecs-anywhere
-    iam_role: ecsAnywhereRole
+    ecs_anywhere_aws_region: us-west-2
+    ecs_anywhere_aws_ecs_cluster: ecs-anywhere
+    ecs_anywhere_iam_role: ecsAnywhereRole
   tasks:
     - name: Include role for deregistering SSM instance
       ansible.builtin.include_role:

--- a/playbooks/ecs-anywhere.yml
+++ b/playbooks/ecs-anywhere.yml
@@ -3,9 +3,9 @@
   hosts: aws_ecs
   become: true
   vars:
-    aws_region: us-west-2
-    aws_ecs_cluster: ecs-anywhere
-    iam_role: ecsAnywhereRole
+    ecs_anywhere_aws_region: us-west-2
+    ecs_anywhere_aws_ecs_cluster: ecs-anywhere
+    ecs_anywhere_iam_role: ecsAnywhereRole
   tasks:
     - name: Import ECS Anywhere role
       ansible.builtin.import_role:

--- a/playbooks/join-ecs-cluster.yml
+++ b/playbooks/join-ecs-cluster.yml
@@ -2,9 +2,9 @@
 - name: Join ECS Cluster
   hosts: aws_ecs
   vars:
-    aws_region: us-west-2
-    aws_ecs_cluster: ecs-anywhere
-    iam_role: ecsAnywhereRole
+    ecs_anywhere_aws_region: us-west-2
+    ecs_anywhere_aws_ecs_cluster: ecs-anywhere
+    ecs_anywhere_iam_role: ecsAnywhereRole
   tasks:
     - name: Deregister from SSM Instance
       ansible.builtin.include_role:

--- a/playbooks/register-ssm-instance.yml
+++ b/playbooks/register-ssm-instance.yml
@@ -1,8 +1,10 @@
 ---
-- hosts: aws_ecs
+- name: Register ECS Anywhere Instance
+  hosts: aws_ecs
+  gather_facts: false
+  become: true
   tasks:
-    - include_role:
+    - name: Include ECS Anywhere Role
+      ansible.builtin.include_role:
         name: gaggle_net.ecs_anywhere.ecs_anywhere
         tasks_from: register-ssm-instance
-  gather_facts: no
-  become: yes

--- a/plugins/modules/aws_ssm_activation.py
+++ b/plugins/modules/aws_ssm_activation.py
@@ -10,7 +10,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import (
 
 DOCUMENTATION = r'''
 ---
-module: aws_ssm
+module: aws_ssm_activation
 version_added: 1.1.0
 short_description: Perform various System Manager management tasks.
 description:
@@ -60,16 +60,16 @@ EXAMPLES = '''
   hosts: localhost
   tasks:
     - name: Create SSM Activation
-      aws_ssm_activation:
+      gaggle_net.ecs_anywhere.aws_ssm_activation:
         state: create
-        ecs_anywhere_iam_role: ecsAnywhereRole
+        iam_role: ecsAnywhereRole
         region: us-west-2
 
 - name: Delete SSM Activation Example
   hosts: localhost
   tasks:
     - name: Delete SSM Activation
-      aws_ssm_activation:
+      gaggle_net.ecs_anywhere.aws_ssm_activation:
         state: delete
         activation_id: 12345678
 
@@ -77,7 +77,7 @@ EXAMPLES = '''
   hosts: localhost
   tasks:
     - name: Get SSM Activation
-      aws_ssm_activation:
+      gaggle_net.ecs_anywhere.aws_ssm_activation:
         state: get
 '''
 

--- a/plugins/modules/aws_ssm_instance.py
+++ b/plugins/modules/aws_ssm_instance.py
@@ -5,13 +5,26 @@ from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
 
+try:
+    import botocore
+except ImportError:
+    botocore = None  # raise an error with a custom message
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import (
+    AnsibleAWSModule, is_boto3_error_code
+)
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
+    AWSRetry, ansible_dict_to_boto3_filter_list
+)
+
 DOCUMENTATION = r'''
 ---
 module: aws_ssm_instance
 version_added: 1.1.0
 short_description: Perform various System Manager instance tasks.
 description:
-    - This module allows the user to get SSM instance information or deregister an SSM instance
+    - This module allows the user to get SSM instance information or
+      deregister an SSM instance
 options:
   state:
     description:
@@ -32,9 +45,10 @@ options:
     type: str
   filters:
     description:
-      - A dict of filters to apply. Each dict item consists of a filter key and a filter value. See
-        U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html) for possible filters. Filter
-        names and values are case sensitive.
+      - A dict of filters to apply. Each dict item consists of a filter key
+        and a filter value. See:
+        U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html) # noqa: E501
+        For possible filters. Filter names and values are case sensitive.
     required: false
     default: {}
     type: dict
@@ -49,20 +63,22 @@ author:
 '''
 
 EXAMPLES = '''
-- hosts: localhost
+- name: Deregister SSM Instance Example
+  hosts: localhost
   tasks:
-  - name: deregister ssm instance
-    local_action:
+    - name: Deregister SSM Instance
+      delegate_to: localhost
       module: gagglenet.ecs_anywhere.aws_ssm_instance
       state: deregister
-      instance_id:  mi-0db497f1c7f0f903c
+      instance_id: mi-0db497f1c7f0f903c
 
-- hosts: localhost
+- name: Get SSM Instances Example
+  hosts: localhost
   tasks:
-  - name: get ssm instances
-  local_action:
-    module: gagglenet.ecs_anywhere_aws_ssm_instance
-    state: get
+    - name: Get SSM Instances
+      delegate_to: localhost
+      module: gagglenet.ecs_anywhere_aws_ssm_instance
+      state: get
 '''
 
 RETURN = '''
@@ -76,16 +92,6 @@ output:
   returned: state is delete
 '''
 
-try:
-    import botocore
-except ImportError:
-    pass  # Handled by AnsibleAWSModule
-
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
-
 
 @AWSRetry.jittered_backoff()
 def _describe_instances(connection, **params):
@@ -94,51 +100,62 @@ def _describe_instances(connection, **params):
 
 
 def get_ssm_instance_info(module, client):
-    instance_ids = module.params.get("instance_ids")
     filters = ansible_dict_to_boto3_filter_list(module.params.get("filters"))
 
     try:
         ssm_output = _describe_instances(client, Filters=filters)
+        module.exit_json(
+            msg="SSM Activation List",
+            instance_list=ssm_output['InstanceInformationList']
+        )
     except is_boto3_error_code('InvalidActivationId') as e:
-        module.warn("Could not find activation.")
-    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
-        module.fail_json_aws(e, msg=e)
-    module.exit_json(msg="SSM Activation List", instance_list=ssm_output['InstanceInformationList'])
+        # Log the exception details and warn the user
+        module.warn(f"Could not find activation. Error: {e}")
+    except (botocore.exceptions.BotoCoreError,
+            botocore.exceptions.ClientError) as e:
+        # Fail and provide the exception details in the error message
+        module.fail_json_aws(e, msg=f"Error in get_ssm_instance_info: {e}")
 
 
 def deregister_ssm_instance(module, client):
     instance_id = module.params.get("instance_id")
-    ssm_output = None
 
     try:
-        ssm_output = client.deregister_managed_instance(
-            InstanceId=instance_id
+        ssm_output = client.deregister_managed_instance(InstanceId=instance_id)
+        module.exit_json(
+            msg="Deregistered SSM Instance",
+            output=ssm_output, changed=True
         )
     except is_boto3_error_code('InvalidInstanceId') as e:
-        module.warn("Could not find instance.")
-    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
-        module.fail_json_aws(e, msg=e)
-    module.exit_json(msg="Deregistered SSM Instance", output=ssm_output, changed=True)
+        module.warn(f"Could not find instance. Error: {e}")
+    except (botocore.exceptions.BotoCoreError,
+            botocore.exceptions.ClientError) as e:
+        module.fail_json_aws(
+            e, msg=f"Error in deregister_ssm_instance_info: {e}"
+            )
 
 
 def main():
+    if botocore is None:
+        AnsibleAWSModule().fail_json(
+            msg="The botocore library is required for this module but is not"
+                "installed. Please install botocore and try again."
+        )
+
     argument_spec = dict(
         instance_id=dict(type='str'),
-        state=dict(type='str', required=True, choices=['deregister', 'get'],
-                   aliases=['command']),
+        state=dict(type='str', required=True,
+                   choices=['deregister', 'get'], aliases=['command']),
         filters=dict(default={}, type='dict')
     )
 
     module = AnsibleAWSModule(
         argument_spec=argument_spec,
-        mutually_exclusive=[
-            ['instance_ids', 'filters']
-        ],
+        mutually_exclusive=[['instance_ids', 'filters']],
         supports_check_mode=True,
     )
 
     command = module.params['state']
-
     client = module.client('ssm')
 
     if command == 'deregister':

--- a/plugins/modules/aws_ssm_instance.py
+++ b/plugins/modules/aws_ssm_instance.py
@@ -17,14 +17,15 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
     AWSRetry, ansible_dict_to_boto3_filter_list
 )
 
+
 DOCUMENTATION = r'''
 ---
 module: aws_ssm_instance
-version_added: 1.1.0
+version_added: "1.1.0"
 short_description: Perform various System Manager instance tasks.
 description:
-    - This module allows the user to get SSM instance information or
-      deregister an SSM instance
+  - This module allows the user to get SSM instance information or
+    deregister an SSM instance.
 options:
   state:
     description:
@@ -35,20 +36,19 @@ options:
     type: str
   instance_id:
     description:
-      - The ID of the SSM instance
+      - The ID of the SSM instance.
     required: false
     type: str
   region:
     description:
-      - AWS Region
+      - AWS Region.
     required: true
     type: str
   filters:
     description:
-      - A dict of filters to apply. Each dict item consists of a filter key
-        and a filter value. See:
-        U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html) # noqa: E501
-        For possible filters. Filter names and values are case sensitive.
+      - "A dict of filters to apply. Each dict item consists of a filter key and a filter value. \
+        See U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html) for possible filters. \
+        Filter names and values are case sensitive."
     required: false
     default: {}
     type: dict

--- a/roles/ecs_anywhere/README.md
+++ b/roles/ecs_anywhere/README.md
@@ -20,14 +20,14 @@ This role requires Ansible 2.4 or higher and AWS CLI v2.
 
 | variable | description | required? | default |
 | -------- | ----------- | ---------- | ------- |
-| iam_role | Which IAM role to associate with instance | yes | - |
-| aws_ecs_cluster | Name of ECS cluster to use | yes | - |
-| aws_region | Which region to use for this ECS instance | yes | `us-west-2` |
-| aws_install_dir | Where to install ECS anywhere | no | `/opt/amazon/ecs-anywhere` |
-| aws_script_url | Location of install script | no | `https://amazon-ecs-agent.s3.amazonaws.com/ecs-anywhere-install-latest.sh` |
-| use_sudo_for_local_tasks | Override default sudo behaviour for local tasks | no | true |
-| aws_sso_profile | SSO profile used to run local task | no | omit |
-| include_docker_role | Install docker as a dependnecy | no | when os = rhel8 |
+| ecs_anywhere_iam_role | Which IAM role to associate with instance | yes | - |
+| ecs_anywhere_aws_ecs_cluster | Name of ECS cluster to use | yes | - |
+| ecs_anywhere_aws_region | Which region to use for this ECS instance | yes | `us-west-2` |
+| ecs_anywhere_aws_install_dir | Where to install ECS anywhere | no | `/opt/amazon/ecs-anywhere` |
+| ecs_anywhere_aws_script_url | Location of install script | no | `https://amazon-ecs-agent.s3.amazonaws.com/ecs-anywhere-install-latest.sh` |
+| ecs_anywhere_use_sudo_for_local_tasks | Override default sudo behaviour for local tasks | no | true |
+| ecs_anywhere_aws_sso_profile | SSO profile used to run local task | no | omit |
+| ecs_anywhere_include_docker_role | Install docker as a dependnecy | no | when os = rhel8 |
 
 ## Example Playbooks
 
@@ -42,9 +42,9 @@ Install ECS and SSM agents and register SSM node
       name: gaggle_net.ecs_anywhere.ecs_anywhere
       tasks_from: aws-script-install
     vars:
-      iam_role: ecsAnywhereRole
-      aws_ecs_cluster: ecs-anywhere
-      aws_region: us-west-2
+      ecs_anywhere_iam_role: ecsAnywhereRole
+      ecs_anywhere_aws_ecs_cluster: ecs-anywhere
+      ecs_anywhere_aws_region: us-west-2
 
 ```
 

--- a/roles/ecs_anywhere/defaults/main.yml
+++ b/roles/ecs_anywhere/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
-aws_region: us-west-2
-aws_install_dir: /opt/amazon/ecs-anywhere
-aws_script_url: https://amazon-ecs-agent.s3.amazonaws.com/ecs-anywhere-install-latest.sh
-use_sudo_for_local_tasks: true
-include_docker_role: "{{ ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8' }}"
+ecs_anywhere_aws_region: us-west-2
+ecs_anywhere_aws_install_dir: /opt/amazon/ecs-anywhere
+ecs_anywhere_aws_script_url: https://amazon-ecs-agent.s3.amazonaws.com/ecs-anywhere-install-latest.sh
+ecs_anywhere_use_sudo_for_local_tasks: true
+ecs_anywhere_include_docker_role: "{{ ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8' }}"
 ...

--- a/roles/ecs_anywhere/meta/main.yml
+++ b/roles/ecs_anywhere/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   role_name: ecs_anywhere
   author: gagglenet
-  descpription: Ansible role that configures ecs anywhere instance
+  description: Ansible role that configures ecs anywhere instance
   company: Gaggle Net
   issue_tracker_url: https://github.com/gaggle-net/ansible-ecs-anywhere-playbook/issues
   license: MIT
@@ -11,12 +11,11 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - 7
-        - 8
+        - '7'
+        - '8'
     - name: Fedora
       versions:
-        - 27
-        - 28
+        - all
   galaxy_tags:
     - aws
     - centos

--- a/roles/ecs_anywhere/meta/main.yml
+++ b/roles/ecs_anywhere/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 galaxy_info:
-  role_name: ecs-anywhere
+  role_name: ecs_anywhere
   author: gagglenet
   descpription: Ansible role that configures ecs anywhere instance
   company: Gaggle Net
@@ -24,4 +24,4 @@ galaxy_info:
 
 dependencies:
   - name: geerlingguy.docker
-    when: include_docker_role | default(true)
+    when: ecs_anywhere_include_docker_role | default(true)

--- a/roles/ecs_anywhere/tasks/aws-script-install.yml
+++ b/roles/ecs_anywhere/tasks/aws-script-install.yml
@@ -3,7 +3,7 @@
 
 - name: ECS Anywhere | Download ECS Anywhere Install Script
   get_url:
-    url: "{{ aws_script_url }}"
+    url: "{{ ecs_anywhere_aws_script_url }}"
     dest: /tmp
     mode: '0550'
   become: yes
@@ -12,11 +12,11 @@
   local_action:
     module: gaggle_net.ecs_anywhere.aws_ssm_activation
     state: create
-    iam_role: "{{ iam_role }}"
-    region: "{{ aws_region }}"
-  become: "{{ use_sudo_for_local_tasks }}"
+    iam_role: "{{ ecs_anywhere_iam_role }}"
+    region: "{{ ecs_anywhere_aws_region }}"
+  become: "{{ ecs_anywhere_use_sudo_for_local_tasks }}"
   environment:
-    AWS_PROFILE: "{{ aws_sso_profile | default(omit) }}"
+    AWS_PROFILE: "{{ ecs_anywhere_aws_sso_profile | default(omit) }}"
   register: ssm_activation_info
 
 - set_fact:
@@ -25,7 +25,7 @@
 
 - name: ECS Anywhere | Run ECS Anywhere Install Script and Register SSM Agent
   shell: >
-    /tmp/ecs-anywhere-install-latest.sh --region "{{ aws_region }}" --cluster "{{ aws_ecs_cluster }}"
+    /tmp/ecs-anywhere-install-latest.sh --region "{{ ecs_anywhere_aws_region }}" --cluster "{{ ecs_anywhere_aws_ecs_cluster }}"
     --activation-id "{{ ssm_activation_id }}" --activation-code "{{ ssm_activation_code }}"
     {{ '--docker-install-source none' if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8') else '' }}
   become: true

--- a/roles/ecs_anywhere/tasks/aws-script-install.yml
+++ b/roles/ecs_anywhere/tasks/aws-script-install.yml
@@ -1,32 +1,41 @@
 ---
-- import_tasks: pre-checks.yml
+- name: Import pre-checks
+  ansible.builtin.import_tasks: pre-checks.yml
 
 - name: ECS Anywhere | Download ECS Anywhere Install Script
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ ecs_anywhere_aws_script_url }}"
     dest: /tmp
     mode: '0550'
-  become: yes
+  become: true
 
 - name: ECS Anywhere | Create SSM Activation Code
-  local_action:
-    module: gaggle_net.ecs_anywhere.aws_ssm_activation
-    state: create
-    iam_role: "{{ ecs_anywhere_iam_role }}"
-    region: "{{ ecs_anywhere_aws_region }}"
-  become: "{{ ecs_anywhere_use_sudo_for_local_tasks }}"
+  delegate_to: localhost
+  ansible.builtin.shell:
+    cmd: >
+      gaggle_net.ecs_anywhere.aws_ssm_activation
+      state=create
+      iam_role="{{ ecs_anywhere_iam_role }}"
+      region="{{ ecs_anywhere_aws_region }}"
   environment:
     AWS_PROFILE: "{{ ecs_anywhere_aws_sso_profile | default(omit) }}"
   register: ssm_activation_info
+  become: "{{ ecs_anywhere_use_sudo_for_local_tasks }}"
+  changed_when: >-
+    ssm_activation_info.activation_id is defined and
+    ssm_activation_info.activation_code is defined
 
-- set_fact:
+- name: Set SSM Activation Fact
+  ansible.builtin.set_fact:
     ssm_activation_id: "{{ ssm_activation_info.activation_id }}"
     ssm_activation_code: "{{ ssm_activation_info.activation_code }}"
 
 - name: ECS Anywhere | Run ECS Anywhere Install Script and Register SSM Agent
-  shell: >
-    /tmp/ecs-anywhere-install-latest.sh --region "{{ ecs_anywhere_aws_region }}" --cluster "{{ ecs_anywhere_aws_ecs_cluster }}"
-    --activation-id "{{ ssm_activation_id }}" --activation-code "{{ ssm_activation_code }}"
-    {{ '--docker-install-source none' if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8') else '' }}
+  ansible.builtin.shell:
+    cmd: >
+      /tmp/ecs-anywhere-install-latest.sh --region "{{ ecs_anywhere_aws_region }}" --cluster "{{ ecs_anywhere_aws_ecs_cluster }}"
+      --activation-id "{{ ssm_activation_id }}" --activation-code "{{ ssm_activation_code }}"
+      {{ '--docker-install-source none' if ecs_anywhere_include_docker_role else '' }}
   become: true
   register: ecs_registration
+  changed_when: ecs_registration.rc == 0

--- a/roles/ecs_anywhere/tasks/deregister-ssm-instance.yml
+++ b/roles/ecs_anywhere/tasks/deregister-ssm-instance.yml
@@ -14,9 +14,9 @@
     state: deregister
     instance_id: "{{ ssm_id }}"
     region: us-west-2
-  become: "{{ use_sudo_for_local_tasks }}"
+  become: "{{ ecs_anywhere_use_sudo_for_local_tasks }}"
   environment:
-    AWS_PROFILE: "{{ aws_sso_profile | default(omit) }}"
+    AWS_PROFILE: "{{ ecs_anywhere_aws_sso_profile | default(omit) }}"
 
 - name: ECS Anywhere | Delete Local Registration Info
   file:

--- a/roles/ecs_anywhere/tasks/deregister-ssm-instance.yml
+++ b/roles/ecs_anywhere/tasks/deregister-ssm-instance.yml
@@ -1,61 +1,63 @@
 ---
 - name: ECS Anywhere | Get SSM Instance Info
-  shell: ssm-cli get-instance-information
+  ansible.builtin.command: ssm-cli get-instance-information
   register: ssm_instance_info
   become: true
+  changed_when: false
 
-- set_fact:
+- name: Set SSM ID Fact
+  ansible.builtin.set_fact:
     ssm_id: "{{ (ssm_instance_info.stdout | from_json) | json_query('\"instance-id\"') }}"
-
+  changed_when: ssm_id is defined
 
 - name: ECS Anywhere | Deregister SSM Instance
-  local_action:
-    module: gaggle_net.ecs_anywhere.aws_ssm_instance
+  gaggle_net.ecs_anywhere.aws_ssm_instance:
     state: deregister
     instance_id: "{{ ssm_id }}"
-    region: us-west-2
+    region: "{{ ecs_anywhere_aws_region }}"
+  delegate_to: localhost
   become: "{{ ecs_anywhere_use_sudo_for_local_tasks }}"
   environment:
     AWS_PROFILE: "{{ ecs_anywhere_aws_sso_profile | default(omit) }}"
 
 - name: ECS Anywhere | Delete Local Registration Info
-  file:
+  ansible.builtin.file:
     path: /var/lib/amazon/ssm/registration
     state: absent
   become: true
 
 - name: ECS Anywhere | Delete ECS Agent Data
-  file:
+  ansible.builtin.file:
     path: /var/lib/ecs/data/agent.db
     state: absent
   become: true
 
 - name: ECS Anywhere | Stop the SSM Agent Service
-  systemd:
+  ansible.builtin.systemd:
     name: amazon-ssm-agent.service
     state: stopped
   become: true
 
 - name: ECS Anywhere | Stop the ECS Agent Service
-  systemd:
+  ansible.builtin.systemd:
     name: ecs.service
     state: stopped
   become: true
 
 - name: ECS Anywhere | Install python3-docker
-  yum:
+  ansible.builtin.yum:
     name: python3-docker
     state: installed
   become: true
 
 - name: ECS Anywhere | Get List of All Running Docker Containers
-  docker_host_info:
+  community.docker.docker_host_info:
     containers: true
   register: docker_info
   become: true
 
 - name: ECS Anywhere | Remove All Docker Containers
-  docker_container:
+  community.docker.docker_container:
     name: '{{ item.Names[0] | regex_replace("^/", "") }}'
     state: absent
   loop: "{{ docker_info.containers }}"

--- a/roles/ecs_anywhere/tasks/join-ecs-cluster.yml
+++ b/roles/ecs_anywhere/tasks/join-ecs-cluster.yml
@@ -1,6 +1,9 @@
 ---
-- import_tasks: pre-checks.yml
+- name: Import pre-checks
+  ansible.builtin.import_tasks: pre-checks.yml
 
-- import_tasks: deregister-ssm-instance.yml
-    
-- import_tasks: register-ssm-instance.yml
+- name: Deregister SSM instance
+  ansible.builtin.import_tasks: deregister-ssm-instance.yml
+
+- name: Register SSM instance
+  ansible.builtin.import_tasks: register-ssm-instance.yml

--- a/roles/ecs_anywhere/tasks/main.yml
+++ b/roles/ecs_anywhere/tasks/main.yml
@@ -1,2 +1,3 @@
 ---
-- import_tasks: aws-script-install.yml
+- name: Import AWS script installation tasks
+  ansible.builtin.import_tasks: aws-script-install.yml

--- a/roles/ecs_anywhere/tasks/pre-checks.yml
+++ b/roles/ecs_anywhere/tasks/pre-checks.yml
@@ -1,10 +1,10 @@
 ---
 - name: ECS Anywhere | Check If Using cgroups V2
-  stat:
+  ansible.builtin.stat:
     path: /sys/fs/cgroup/cgroup.controllers
   register: cgroup_controllers
- 
+
 - name: ECS Anywhere | Fail If Using cgroups V2
-  fail:
+  ansible.builtin.fail:
     msg: Your system is using cgroups v2, which is not supported by ECS
   when: cgroup_controllers.stat.exists

--- a/roles/ecs_anywhere/tasks/provision-ecs-instance.yml
+++ b/roles/ecs_anywhere/tasks/provision-ecs-instance.yml
@@ -1,36 +1,36 @@
 ---
-- name: check if using cgroup v2
-  stat:
+- name: Check if using cgroup v2
+  ansible.builtin.stat:
     path: /sys/fs/cgroup/cgroup.controllers
   register: cgroupv2
 
-- name: fail if using cgroup v2
-  fail:
-    msg: Your system is using cgroups v2, which is not supported by ECS.
+- name: Fail if using cgroup v2
+  ansible.builtin.fail:
+    msg: "Your system is using cgroups v2, which is not supported by ECS."
   when: cgroupv2.stat.exists
 
-- name: copy aws gpg key
-  copy:
+- name: Copy AWS GPG key
+  ansible.builtin.copy:
     src: aws-ecs-gpg-key
     dest: /tmp/aws-ecs-gpg-key
+    mode: '0644'  # Add a specific file permission to address risky file permissions
 
-- name: import pgp key
-  rpm_key:
+- name: Import PGP key
+  ansible.builtin.rpm_key:
     state: present
     key: /tmp/aws-ecs-gpg-key
-    
-- name: install jq
-  yum:
-    name: jq
-    state: latest
 
-- name: set architecture
-  set_fact:
+- name: Install jq
+  ansible.builtin.yum:
+    name: jq
+    state: present  # Change from 'latest' to 'present'
+
+- name: Set architecture
+  ansible.builtin.set_fact:
     arch: amd64
   when: ansible_facts['architecture'] == 'x86_64'
 
-- name: install ssm agent
-  dnf:
-    name: https://s3.{{ ecs_anywhere_aws_region }}.amazonaws.com/amazon-ssm-{{ ecs_anywhere_aws_region }}/latest/linux_{{ arch }}/amazon-ssm-agent.rpm
+- name: Install SSM agent
+  ansible.builtin.dnf:
+    name: "https://s3.{{ ecs_anywhere_aws_region }}.amazonaws.com/amazon-ssm-{{ ecs_anywhere_aws_region }}/latest/linux_{{ arch }}/amazon-ssm-agent.rpm"
     state: present
-    

--- a/roles/ecs_anywhere/tasks/provision-ecs-instance.yml
+++ b/roles/ecs_anywhere/tasks/provision-ecs-instance.yml
@@ -31,6 +31,6 @@
 
 - name: install ssm agent
   dnf:
-    name: https://s3.{{ aws_region }}.amazonaws.com/amazon-ssm-{{ aws_region }}/latest/linux_{{ arch }}/amazon-ssm-agent.rpm
+    name: https://s3.{{ ecs_anywhere_aws_region }}.amazonaws.com/amazon-ssm-{{ ecs_anywhere_aws_region }}/latest/linux_{{ arch }}/amazon-ssm-agent.rpm
     state: present
     

--- a/roles/ecs_anywhere/tasks/register-ssm-instance.yml
+++ b/roles/ecs_anywhere/tasks/register-ssm-instance.yml
@@ -15,11 +15,11 @@
   local_action:
     module: gaggle_net.ecs_anywhere.aws_ssm_activation
     state: create
-    iam_role: "{{ iam_role }}"
-    region: "{{ aws_region }}"
-  become: "{{ use_sudo_for_local_tasks }}"
+    iam_role: "{{ ecs_any_where_iam_role }}"
+    region: "{{ ecs_anywhere_aws_region }}"
+  become: "{{ ecs_anywhere_use_sudo_for_local_tasks }}"
   environment:
-    AWS_PROFILE: "{{ aws_sso_profile | default(omit) }}"
+    AWS_PROFILE: "{{ ecs_anywhere_aws_sso_profile | default(omit) }}"
   register: ssm_activation_info
 
 - set_fact:
@@ -31,12 +31,12 @@
     state: present
     path: /etc/ecs/ecs.config
     regexp: '^[# ]*ECS_CLUSTER\s*=\s*'
-    line: "ECS_CLUSTER={{ aws_ecs_cluster }}"
+    line: "ECS_CLUSTER={{ ecs_anywhere_aws_ecs_cluster }}"
   become: true
 
 - name: ECS Anywhere | Register the SSM Agent
   shell:
-    "/usr/bin/amazon-ssm-agent -register -y -code {{ ssm_activation_code }} -id {{ ssm_activation_id }} -region {{ aws_region }}"
+    "/usr/bin/amazon-ssm-agent -register -y -code {{ ssm_activation_code }} -id {{ ssm_activation_id }} -region {{ ecs_anywhere_aws_region }}"
   become: true
 
 - name: ECS Anywhere | Start the SSM agent

--- a/roles/ecs_anywhere/tasks/register-ssm-instance.yml
+++ b/roles/ecs_anywhere/tasks/register-ssm-instance.yml
@@ -1,33 +1,34 @@
 ---
 - name: ECS Anywhere | Stop the ECS Service
-  systemd:
+  ansible.builtin.systemd:
     name: ecs.service
     state: stopped
   become: true
 
 - name: ECS Anywhere | Delete ECS Agent Data
-  file:
+  ansible.builtin.file:
     path: /var/lib/ecs/data/agent.db
     state: absent
   become: true
 
 - name: ECS Anywhere | Create SSM Activation Code
-  local_action:
-    module: gaggle_net.ecs_anywhere.aws_ssm_activation
+  gaggle_net.ecs_anywhere.aws_ssm_activation:
     state: create
     iam_role: "{{ ecs_any_where_iam_role }}"
     region: "{{ ecs_anywhere_aws_region }}"
+  delegate_to: localhost
   become: "{{ ecs_anywhere_use_sudo_for_local_tasks }}"
   environment:
     AWS_PROFILE: "{{ ecs_anywhere_aws_sso_profile | default(omit) }}"
   register: ssm_activation_info
 
-- set_fact:
+- name: Set SSM Activation Info
+  ansible.builtin.set_fact:
     ssm_activation_id: "{{ ssm_activation_info.activation_id }}"
     ssm_activation_code: "{{ ssm_activation_info.activation_code }}"
 
 - name: ECS Anywhere | Set the ECS Cluster Name
-  lineinfile:
+  ansible.builtin.lineinfile:
     state: present
     path: /etc/ecs/ecs.config
     regexp: '^[# ]*ECS_CLUSTER\s*=\s*'
@@ -35,19 +36,19 @@
   become: true
 
 - name: ECS Anywhere | Register the SSM Agent
-  shell:
-    "/usr/bin/amazon-ssm-agent -register -y -code {{ ssm_activation_code }} -id {{ ssm_activation_id }} -region {{ ecs_anywhere_aws_region }}"
+  ansible.builtin.command:
+    cmd: "/usr/bin/amazon-ssm-agent -register -y -code {{ ssm_activation_code }} -id {{ ssm_activation_id }} -region {{ ecs_anywhere_aws_region }}"
   become: true
+  changed_when: "ssm_activation_code is defined and ssm_activation_id is defined"
 
-- name: ECS Anywhere | Start the SSM agent
-  systemd:
+- name: ECS Anywhere | Start the SSM Agent
+  ansible.builtin.systemd:
     name: amazon-ssm-agent.service
     state: started
   become: true
 
-
 - name: ECS Anywhere | Start the ECS Service
-  systemd:
+  ansible.builtin.systemd:
     name: ecs.service
     state: started
   become: true


### PR DESCRIPTION
Just walking though ansible-lint and flake8 recommendations for the case of the python modules included in this collection.

I got up to the part where ansible-lint said this: 

```
var-naming[no-role-prefix]: Variables names from within roles should use ecs_anywhere_ as a prefix. (vars: aws_region)
roles/ecs_anywhere/defaults/main.yml:2

var-naming[no-role-prefix]: Variables names from within roles should use ecs_anywhere_ as a prefix. (vars: aws_install_dir)
roles/ecs_anywhere/defaults/main.yml:3

var-naming[no-role-prefix]: Variables names from within roles should use ecs_anywhere_ as a prefix. (vars: aws_script_url)
roles/ecs_anywhere/defaults/main.yml:4

var-naming[no-role-prefix]: Variables names from within roles should use ecs_anywhere_ as a prefix. (vars: use_sudo_for_local_tasks)
roles/ecs_anywhere/defaults/main.yml:5

var-naming[no-role-prefix]: Variables names from within roles should use ecs_anywhere_ as a prefix. (vars: include_docker_role)
roles/ecs_anywhere/defaults/main.yml:6

```
And that was a bit of work going through and renaming some variables.  Out of time for today (and this weekend) to work on this, so I'm still looking to fix the rest of these issues: 

```
ansible-collection-ecs-anywhere on  main [!] via  v3.10.12 (venv)
❯ ansible-lint 
 [ERROR]: Unable to parse documentation in python file 'plugins/modules/aws_ssm_instance.py': mapping values are not allowed in this context   in "<unicode string>", line 30, column 32
WARNING  Unable to load module aws_ssm_activation at /tmp/tmpoblc311d_aws_ssm_activation.py.yaml:5 for options validation
WARNING  Unable to load module aws_ssm_activation at /tmp/tmpoblc311d_aws_ssm_activation.py.yaml:14 for options validation
WARNING  Unable to load module aws_ssm_activation at /tmp/tmpoblc311d_aws_ssm_activation.py.yaml:22 for options validation
WARNING  Unable to resolve FQCN for module aws_ssm_activation
WARNING  Listing 64 violation(s) that are fatal
schema[meta]: $.galaxy_info Additional properties are not allowed ('descpription' was unexpected). See https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#using-role-dependencies
roles/ecs_anywhere/meta/main.yml:1  Returned errors will not include exact line numbers, but they will mention
the schema name being used as a tag, like ``schema[playbook]``,
``schema[tasks]``.

This rule is not skippable and stops further processing of the file.

If incorrect schema was picked, you might want to either:

* move the file to standard location, so its file is detected correctly.
* use ``kinds:`` option in linter config to help it pick correct file type.


fqcn[action-core]: Use FQCN for builtin module actions (import_tasks).
roles/ecs_anywhere/tasks/aws-script-install.yml:2 Use `ansible.builtin.import_tasks` or `ansible.legacy.import_tasks` instead.

name[missing]: All tasks should be named.
roles/ecs_anywhere/tasks/aws-script-install.yml:2 Task/Handler: import_tasks pre-checks.yml

fqcn[action-core]: Use FQCN for builtin module actions (get_url).
roles/ecs_anywhere/tasks/aws-script-install.yml:4 Use `ansible.builtin.get_url` or `ansible.legacy.get_url` instead.

yaml[truthy]: Truthy value should be one of [false, true]
roles/ecs_anywhere/tasks/aws-script-install.yml:9

deprecated-local-action: Do not use 'local_action', use 'delegate_to: localhost'.
roles/ecs_anywhere/tasks/aws-script-install.yml:11 Task/Handler: ECS Anywhere | Create SSM Activation Code

fqcn[action-core]: Use FQCN for builtin module actions (set_fact).
roles/ecs_anywhere/tasks/aws-script-install.yml:22 Use `ansible.builtin.set_fact` or `ansible.legacy.set_fact` instead.

name[missing]: All tasks should be named.
roles/ecs_anywhere/tasks/aws-script-install.yml:22 Task/Handler: set_fact ssm_activation_id={{ ssm_activation_info.activation_id }} ssm_activation_code={{ ssm_activation_info.activation_code }}

fqcn[action-core]: Use FQCN for builtin module actions (shell).
roles/ecs_anywhere/tasks/aws-script-install.yml:26 Use `ansible.builtin.shell` or `ansible.legacy.shell` instead.

no-changed-when: Commands should not change things if nothing needs doing.
roles/ecs_anywhere/tasks/aws-script-install.yml:26 Task/Handler: ECS Anywhere | Run ECS Anywhere Install Script and Register SSM Agent

command-instead-of-shell: Use shell only when shell functionality is required.
roles/ecs_anywhere/tasks/deregister-ssm-instance.yml:2 Task/Handler: ECS Anywhere | Get SSM Instance Info

fqcn[action-core]: Use FQCN for builtin module actions (shell).
roles/ecs_anywhere/tasks/deregister-ssm-instance.yml:2 Use `ansible.builtin.shell` or `ansible.legacy.shell` instead.

no-changed-when: Commands should not change things if nothing needs doing.
roles/ecs_anywhere/tasks/deregister-ssm-instance.yml:2 Task/Handler: ECS Anywhere | Get SSM Instance Info

fqcn[action-core]: Use FQCN for builtin module actions (set_fact).
roles/ecs_anywhere/tasks/deregister-ssm-instance.yml:7 Use `ansible.builtin.set_fact` or `ansible.legacy.set_fact` instead.

name[missing]: All tasks should be named.
roles/ecs_anywhere/tasks/deregister-ssm-instance.yml:7 Task/Handler: set_fact ssm_id={{ (ssm_instance_info.stdout | from_json) | json_query('"instance-id"') }}

deprecated-local-action: Do not use 'local_action', use 'delegate_to: localhost'.
roles/ecs_anywhere/tasks/deregister-ssm-instance.yml:11 Task/Handler: ECS Anywhere | Deregister SSM Instance

fqcn[action-core]: Use FQCN for builtin module actions (file).
roles/ecs_anywhere/tasks/deregister-ssm-instance.yml:21 Use `ansible.builtin.file` or `ansible.legacy.file` instead.

fqcn[action-core]: Use FQCN for builtin module actions (file).
roles/ecs_anywhere/tasks/deregister-ssm-instance.yml:27 Use `ansible.builtin.file` or `ansible.legacy.file` instead.

fqcn[action-core]: Use FQCN for builtin module actions (systemd).
roles/ecs_anywhere/tasks/deregister-ssm-instance.yml:33 Use `ansible.builtin.systemd` or `ansible.legacy.systemd` instead.

fqcn[action-core]: Use FQCN for builtin module actions (systemd).
roles/ecs_anywhere/tasks/deregister-ssm-instance.yml:39 Use `ansible.builtin.systemd` or `ansible.legacy.systemd` instead.

fqcn[action-core]: Use FQCN for builtin module actions (yum).
roles/ecs_anywhere/tasks/deregister-ssm-instance.yml:45 Use `ansible.builtin.yum` or `ansible.legacy.yum` instead.

fqcn[action]: Use FQCN for module actions, such `community.docker.docker_host_info`.
roles/ecs_anywhere/tasks/deregister-ssm-instance.yml:51 Action `docker_host_info` is not FQCN.

fqcn[action]: Use FQCN for module actions, such `community.docker.docker_container`.
roles/ecs_anywhere/tasks/deregister-ssm-instance.yml:57 Action `docker_container` is not FQCN.

fqcn[action-core]: Use FQCN for builtin module actions (import_tasks).
roles/ecs_anywhere/tasks/join-ecs-cluster.yml:2 Use `ansible.builtin.import_tasks` or `ansible.legacy.import_tasks` instead.

name[missing]: All tasks should be named.
roles/ecs_anywhere/tasks/join-ecs-cluster.yml:2 Task/Handler: import_tasks pre-checks.yml

fqcn[action-core]: Use FQCN for builtin module actions (import_tasks).
roles/ecs_anywhere/tasks/join-ecs-cluster.yml:4 Use `ansible.builtin.import_tasks` or `ansible.legacy.import_tasks` instead.

name[missing]: All tasks should be named.
roles/ecs_anywhere/tasks/join-ecs-cluster.yml:4 Task/Handler: import_tasks deregister-ssm-instance.yml

yaml[trailing-spaces]: Trailing spaces
roles/ecs_anywhere/tasks/join-ecs-cluster.yml:5

fqcn[action-core]: Use FQCN for builtin module actions (import_tasks).
roles/ecs_anywhere/tasks/join-ecs-cluster.yml:6 Use `ansible.builtin.import_tasks` or `ansible.legacy.import_tasks` instead.

name[missing]: All tasks should be named.
roles/ecs_anywhere/tasks/join-ecs-cluster.yml:6 Task/Handler: import_tasks register-ssm-instance.yml

fqcn[action-core]: Use FQCN for builtin module actions (import_tasks).
roles/ecs_anywhere/tasks/main.yml:2 Use `ansible.builtin.import_tasks` or `ansible.legacy.import_tasks` instead.

name[missing]: All tasks should be named.
roles/ecs_anywhere/tasks/main.yml:2 Task/Handler: import_tasks aws-script-install.yml

fqcn[action-core]: Use FQCN for builtin module actions (stat).
roles/ecs_anywhere/tasks/pre-checks.yml:2 Use `ansible.builtin.stat` or `ansible.legacy.stat` instead.

yaml[trailing-spaces]: Trailing spaces
roles/ecs_anywhere/tasks/pre-checks.yml:6

fqcn[action-core]: Use FQCN for builtin module actions (fail).
roles/ecs_anywhere/tasks/pre-checks.yml:7 Use `ansible.builtin.fail` or `ansible.legacy.fail` instead.

fqcn[action-core]: Use FQCN for builtin module actions (stat).
roles/ecs_anywhere/tasks/provision-ecs-instance.yml:2 Use `ansible.builtin.stat` or `ansible.legacy.stat` instead.

name[casing]: All names should start with an uppercase letter.
roles/ecs_anywhere/tasks/provision-ecs-instance.yml:2 Task/Handler: check if using cgroup v2

fqcn[action-core]: Use FQCN for builtin module actions (fail).
roles/ecs_anywhere/tasks/provision-ecs-instance.yml:7 Use `ansible.builtin.fail` or `ansible.legacy.fail` instead.

name[casing]: All names should start with an uppercase letter.
roles/ecs_anywhere/tasks/provision-ecs-instance.yml:7 Task/Handler: fail if using cgroup v2

fqcn[action-core]: Use FQCN for builtin module actions (copy).
roles/ecs_anywhere/tasks/provision-ecs-instance.yml:12 Use `ansible.builtin.copy` or `ansible.legacy.copy` instead.

name[casing]: All names should start with an uppercase letter.
roles/ecs_anywhere/tasks/provision-ecs-instance.yml:12 Task/Handler: copy aws gpg key

risky-file-permissions: File permissions unset or incorrect.
roles/ecs_anywhere/tasks/provision-ecs-instance.yml:12 Task/Handler: copy aws gpg key

fqcn[action-core]: Use FQCN for builtin module actions (rpm_key).
roles/ecs_anywhere/tasks/provision-ecs-instance.yml:17 Use `ansible.builtin.rpm_key` or `ansible.legacy.rpm_key` instead.

name[casing]: All names should start with an uppercase letter.
roles/ecs_anywhere/tasks/provision-ecs-instance.yml:17 Task/Handler: import pgp key

yaml[trailing-spaces]: Trailing spaces
roles/ecs_anywhere/tasks/provision-ecs-instance.yml:21

fqcn[action-core]: Use FQCN for builtin module actions (yum).
roles/ecs_anywhere/tasks/provision-ecs-instance.yml:22 Use `ansible.builtin.yum` or `ansible.legacy.yum` instead.

name[casing]: All names should start with an uppercase letter.
roles/ecs_anywhere/tasks/provision-ecs-instance.yml:22 Task/Handler: install jq

package-latest: Package installs should not use latest.
roles/ecs_anywhere/tasks/provision-ecs-instance.yml:22 Task/Handler: install jq

fqcn[action-core]: Use FQCN for builtin module actions (set_fact).
roles/ecs_anywhere/tasks/provision-ecs-instance.yml:27 Use `ansible.builtin.set_fact` or `ansible.legacy.set_fact` instead.

name[casing]: All names should start with an uppercase letter.
roles/ecs_anywhere/tasks/provision-ecs-instance.yml:27 Task/Handler: set architecture

fqcn[action-core]: Use FQCN for builtin module actions (dnf).
roles/ecs_anywhere/tasks/provision-ecs-instance.yml:32 Use `ansible.builtin.dnf` or `ansible.legacy.dnf` instead.

name[casing]: All names should start with an uppercase letter.
roles/ecs_anywhere/tasks/provision-ecs-instance.yml:32 Task/Handler: install ssm agent

yaml[trailing-spaces]: Trailing spaces
roles/ecs_anywhere/tasks/provision-ecs-instance.yml:36

fqcn[action-core]: Use FQCN for builtin module actions (systemd).
roles/ecs_anywhere/tasks/register-ssm-instance.yml:2 Use `ansible.builtin.systemd` or `ansible.legacy.systemd` instead.

fqcn[action-core]: Use FQCN for builtin module actions (file).
roles/ecs_anywhere/tasks/register-ssm-instance.yml:8 Use `ansible.builtin.file` or `ansible.legacy.file` instead.

deprecated-local-action: Do not use 'local_action', use 'delegate_to: localhost'.
roles/ecs_anywhere/tasks/register-ssm-instance.yml:14 Task/Handler: ECS Anywhere | Create SSM Activation Code

fqcn[action-core]: Use FQCN for builtin module actions (set_fact).
roles/ecs_anywhere/tasks/register-ssm-instance.yml:25 Use `ansible.builtin.set_fact` or `ansible.legacy.set_fact` instead.

name[missing]: All tasks should be named.
roles/ecs_anywhere/tasks/register-ssm-instance.yml:25 Task/Handler: set_fact ssm_activation_id={{ ssm_activation_info.activation_id }} ssm_activation_code={{ ssm_activation_info.activation_code }}

fqcn[action-core]: Use FQCN for builtin module actions (lineinfile).
roles/ecs_anywhere/tasks/register-ssm-instance.yml:29 Use `ansible.builtin.lineinfile` or `ansible.legacy.lineinfile` instead.

command-instead-of-shell: Use shell only when shell functionality is required.
roles/ecs_anywhere/tasks/register-ssm-instance.yml:37 Task/Handler: ECS Anywhere | Register the SSM Agent

fqcn[action-core]: Use FQCN for builtin module actions (shell).
roles/ecs_anywhere/tasks/register-ssm-instance.yml:37 Use `ansible.builtin.shell` or `ansible.legacy.shell` instead.

no-changed-when: Commands should not change things if nothing needs doing.
roles/ecs_anywhere/tasks/register-ssm-instance.yml:37 Task/Handler: ECS Anywhere | Register the SSM Agent

fqcn[action-core]: Use FQCN for builtin module actions (systemd).
roles/ecs_anywhere/tasks/register-ssm-instance.yml:42 Use `ansible.builtin.systemd` or `ansible.legacy.systemd` instead.

fqcn[action-core]: Use FQCN for builtin module actions (systemd).
roles/ecs_anywhere/tasks/register-ssm-instance.yml:49 Use `ansible.builtin.systemd` or `ansible.legacy.systemd` instead.

Read documentation for instructions on how to ignore specific rule violations.

                        Rule Violation Summary                        
 count tag                      profile    rule associated tags       
     2 command-instead-of-shell basic      command-shell, idiom       
     3 deprecated-local-action  basic      deprecations               
     1 schema[meta]             basic      core                       
     8 name[missing]            basic      idiom                      
     4 yaml[trailing-spaces]    basic      formatting, yaml           
     1 yaml[truthy]             basic      formatting, yaml           
     7 name[casing]             moderate   idiom                      
     1 package-latest           safety     idempotency                
     1 risky-file-permissions   safety     unpredictability           
     3 no-changed-when          shared     command-shell, idempotency 
    31 fqcn[action-core]        production formatting                 
     2 fqcn[action]             production formatting                 

Failed: 64 failure(s), 0 warning(s) on 33 files. Last profile that met the validation criteria was 'min'.
```